### PR TITLE
Fix PHP 7.2 and PHP 7.3 incompatibilities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "~7.2.0 || ~7.3.0 || ~7.4.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-        "object-calisthenics/phpcs-calisthenics-rules": "^3.5",
+        "object-calisthenics/phpcs-calisthenics-rules": "~3.8.0",
         "slevomat/coding-standard": "^6.0",
         "squizlabs/php_codesniffer": "^3.5.0",
         "phpcompatibility/php-compatibility": "^9.3"


### PR DESCRIPTION
Fix PHP 7.2 and PHP 7.3 incompatibilities by restricting the `object-calisthenics/phpcs-calisthenics-rules` package to 3.8.x versions.

From 3.9.0, support for PHP 7.2 and 7.3 has been dropped.