### PR TITLE
Add sniff to disallow spaces surrounding an object operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add sniff to disallow spaces surrounding an object operator.
 
 ## [19.0.0] - 2020-10-30
 ### Added

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -144,6 +144,11 @@
             <property name="spacingAfterLast" value="0"/>
         </properties>
     </rule>
+    <rule ref="Squiz.WhiteSpace.ObjectOperatorSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true" />
+        </properties>
+    </rule>
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
         <properties>
             <property name="ignoreBlankLines" value="false"/>


### PR DESCRIPTION
From the [documentation of the Squiz.WhiteSpace.ObjectOperatorSpacing](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties#squizwhitespaceobjectoperatorspacing):

> This sniff ensures there are no spaces surrounding an object operator. Sometimes long object chains are broken over multiple lines to work within a maximum line length, but this sniff will generate an error for these cases by default. Setting the ignoreNewlines property to true will allow newline characters before or after an object operator, and any required padding for alignment.

This PR adds the `Squiz.WhiteSpace.ObjectOperatorSpacing` sniff and sets the `ignoreNewlines` property to `true`.

Spaces before the object operator are not allowed anymore:

```php
$foo ->bar();
```

Spaces after the object operator are not allowed anymore:

```php
$foo-> bar();
```

The following is allowed (this is the desired syntax):

```php
$foo->bar();
```

Note that the following is still allowed:

```php
$foo->
  bar();
```

As well as the following:

```php
$foo
  ->bar();
```

