### PR TITLE
added sniff Generic.Files.LineEndings to only allow linux line endings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add sniff to only allow linux line endings.
 
 ## [20.0.0] - 2021-01-09
 ### Added

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -28,6 +28,7 @@
     <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
     <rule ref="Generic.Commenting.Fixme"/>
     <rule ref="Generic.Commenting.Todo"/>
+    <rule ref="Generic.Files.LineEndings"/>
     <rule ref="Generic.Formatting.MultipleStatementAlignment">
         <properties>
             <property name="maxPadding" value="1" />


### PR DESCRIPTION
This sniff disallows line endings other then linux line endings.
Allowed:
-  LF (\n)

Disallowed:
- CR (\r)
- CR+LF (\r\n)

Although this is already the default for most developers it wasn't explicitly enforced by the standards.