### PR TITLE
Fix: remove duplicate class constant visibility check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Removed duplicate class constant visibility check (removed  SlevomatCodingStandard.Classes.ClassConstantVisibility in favor of PSR12.Properties.ConstantVisibility which is part of the PSR12 ruleset)
 
 ## [20.0.0] - 2021-01-09
 ### Added

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -80,7 +80,6 @@
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
-    <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
     <rule ref="SlevomatCodingStandard.Classes.EmptyLinesAroundClassBraces">
         <properties>
             <property name="linesCountAfterOpeningBrace" value="0"/>


### PR DESCRIPTION
This PR removes checking of the `SlevomatCodingStandard.Classes.ClassConstantVisibility` sniff in favor of the `PSR12.Properties.ConstantVisibility` sniff which is part of the `PSR12` ruleset.

Consider the following the following PHP code:

```php
<?php

declare(strict_types=1);

class Foo
{
    const BAR = 123;
}
```

With the current ISAAC ruleset, phpcs reports the following:

```
-----------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AND 1 WARNING AFFECTING 1 LINE
-----------------------------------------------------------------------------------------------------------------------------------------------------
 7 | WARNING | Visibility must be declared on all constants if your project supports PHP 7.1 or later
   |         | (PSR12.Properties.ConstantVisibility.NotFound)
 7 | ERROR   | Constant \Foo::BAR visibility missing. (SlevomatCodingStandard.Classes.ClassConstantVisibility.MissingConstantVisibility)
-----------------------------------------------------------------------------------------------------------------------------------------------------
```

After merging this PR, phpcs reports the following:

```
-----------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
-----------------------------------------------------------------------------------------------------------------------------------------------------
 7 | WARNING | Visibility must be declared on all constants if your project supports PHP 7.1 or later
   |         | (PSR12.Properties.ConstantVisibility.NotFound)
-----------------------------------------------------------------------------------------------------------------------------------------------------
```