### PR TITLE
Fix: remove explicit reference to ISAAC rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+- Removed explicit reference to ISAAC rules (the rules added by this packages are included automatically)
+
 ## [21.0.0] - 2021-03-09
 ### Removed
 - Removed duplicate class constant visibility check (removed  SlevomatCodingStandard.Classes.ClassConstantVisibility in favor of PSR12.Properties.ConstantVisibility which is part of the PSR12 ruleset)

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -54,9 +54,8 @@
     <rule ref="MySource.PHP.GetRequestData"/>
     <rule ref="PSR12.Operators.OperatorSpacing"/>
 
-    <!-- This block should be ordered alphabetically -->
     <!-- ISAAC -->
-    <rule ref="ISAAC.ControlStructures.DisallowNullCoalesceOperator"/>
+    <!-- all src/Standards/ISAAC/Sniffs/*/*Sniff.php rules are included automatically -->
 
     <!-- This block should be ordered alphabetically -->
     <!-- 3rd party -->


### PR DESCRIPTION
This PR removes explicit references to ISAAC rules, as they are included automatically.