### PR TITLE
Replace deprecated ObjectCalisthenics.Metrics.MaxNestingLevel rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Replace the deprecated `ObjectCalisthenics.Metrics.MaxNestingLevel` rule by `Generic.Metrics.NestingLevel`
+
 ## [21.0.0] - 2021-03-09
 ### Removed
 - Removed duplicate class constant visibility check (removed  SlevomatCodingStandard.Classes.ClassConstantVisibility in favor of PSR12.Properties.ConstantVisibility which is part of the PSR12 ruleset)

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -45,6 +45,12 @@
             <property name="absoluteComplexity" value="20"/>
         </properties>
     </rule>
+    <rule ref="Generic.Metrics.NestingLevel">
+        <properties>
+            <property name="nestingLevel" value="3"/>
+            <property name="absoluteNestingLevel" value="3"/>
+        </properties>
+    </rule>
     <rule ref="Generic.PHP.ForbiddenFunctions">
         <properties>
             <property name="forbiddenFunctions" type="array" value="empty=>null,isset=>null,is_null=>null"/>
@@ -63,11 +69,6 @@
     <rule ref="ObjectCalisthenics.Files.FunctionLength">
         <properties>
             <property name="maxLength" value="25"/>
-        </properties>
-    </rule>
-    <rule ref="ObjectCalisthenics.Metrics.MaxNestingLevel">
-        <properties>
-            <property name="maxNestingLevel" value="3"/>
         </properties>
     </rule>
     <rule ref="ObjectCalisthenics.Metrics.MethodPerClassLimit">


### PR DESCRIPTION
This PR replaces the deprecated `ObjectCalisthenics.Metrics.MaxNestingLevel` rule by `Generic.Metrics.NestingLevel`.

The only real difference between the two rules is that the `ObjectCalisthenics.Metrics.MaxNestingLevel` rule counts the nesting level within closures separately, whereas `Generic.Metrics.NestingLevel` does not. I prefer the latter.

As an example, take the following class:

```php
<?php

declare(strict_types=1);

namespace Test;

class Test
{
    public function functionTest(int $foo): void
    {
        if ($foo > 0) {
            echo '$foo is greater than 0';
            if ($foo > 1) {
                echo '$foo is greater than 1';
                if ($foo > 2) {
                    echo '$foo is greater than 2';
                    if ($foo > 3) {
                        echo '$foo is greater than 3';
                    }
                }
            }
        }
    }

    public function closureTest(int $foo): callable
    {
        return static function () use ($foo) {
            if ($foo > 0) {
                echo '$foo is greater than 0';
                if ($foo > 1) {
                    echo '$foo is greater than 1';
                    if ($foo > 2) {
                        echo '$foo is greater than 2';
                        if ($foo > 3) {
                            echo '$foo is greater than 3';
                        }
                    }
                }
            }
        };
    }
}
```

Previously the `phpcs` tool would generate the following output:

```
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  9 | ERROR | Only 3 indentation levels per function/method. Found 4 levels.
    |       | (ObjectCalisthenics.Metrics.MaxNestingLevel.ObjectCalisthenics\Sniffs\Metrics\MaxNestingLevelSniff)
 27 | ERROR | Only 3 indentation levels per function/method. Found 4 levels.
    |       | (ObjectCalisthenics.Metrics.MaxNestingLevel.ObjectCalisthenics\Sniffs\Metrics\MaxNestingLevelSniff)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

In this PR the `phpcs` tool generates the following output:

```
-------------------------------------------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
-------------------------------------------------------------------------------------------------------------------
  9 | ERROR | Function's nesting level (4) exceeds allowed maximum of 3
    |       | (Generic.Metrics.NestingLevel.MaxExceeded)
 25 | ERROR | Function's nesting level (5) exceeds allowed maximum of 3
    |       | (Generic.Metrics.NestingLevel.MaxExceeded)
-------------------------------------------------------------------------------------------------------------------
```