### PR TITLE
Update slevomat/coding-standard from v6 to v7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changes
+- Update slevomat/coding-standard from v6 to v7
+- Update squizlabs/php_codesniffer from v3.5 to v3.6
+
 ## [21.0.0] - 2021-03-09
 ### Removed
 - Removed duplicate class constant visibility check (removed  SlevomatCodingStandard.Classes.ClassConstantVisibility in favor of PSR12.Properties.ConstantVisibility which is part of the PSR12 ruleset)

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
         "object-calisthenics/phpcs-calisthenics-rules": "^3.5",
-        "slevomat/coding-standard": "7.0.6 as 6.4.1",
+        "slevomat/coding-standard": "7.0.7 as 6.4.1",
         "squizlabs/php_codesniffer": "^3.6.0",
         "phpcompatibility/php-compatibility": "^9.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         "php": "~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
         "object-calisthenics/phpcs-calisthenics-rules": "^3.5",
-        "slevomat/coding-standard": "^6.0",
-        "squizlabs/php_codesniffer": "^3.5.0",
+        "slevomat/coding-standard": "7.0.6 as 6.4.1",
+        "squizlabs/php_codesniffer": "^3.6.0",
         "phpcompatibility/php-compatibility": "^9.3"
     },
     "require-dev": {

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -88,7 +88,6 @@
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>
-    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireShortTernaryOperator"/>
     <rule ref="SlevomatCodingStandard.Files.LineLength">
@@ -123,7 +122,7 @@
     <rule ref="SlevomatCodingStandard.PHP.TypeCast"/>
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <properties>
-            <property name="newlinesCountBetweenOpenTagAndDeclare" value="2"/>
+            <property name="linesCountBeforeDeclare" value="1"/>
             <property name="spacesCountAroundEqualsSign" value="0"/>
         </properties>
     </rule>


### PR DESCRIPTION
This PR updates the `slevomat/coding-standard` dependency from v6 to v7 and the `squizlabs/php_codesniffer` depedency from v3.5 to v3.6

The following changes have been made to the `ruleset.xml` to resolve breaking changes in the new version of the Slevomat Coding Standard:
- `SlevomatCodingStandard.Classes.UnusedPrivateElements`: this rule has been removed in v7 of the Slevomat Coding Standard: in favor of checking using PHPStan
- `SlevomatCodingStandard.TypeHints.DeclareStrictTypes`: replaced `newlinesCountBetweenOpenTagAndDeclare` property by `linesCountBeforeDeclare`

Note that the `slevomat/coding-standard` v7 dependency is added as an alias of v6, because the abandoned `object-calisthenics/phpcs-calisthenics-rules` requires that version.