### PR TITLE
Replace the deprecated ObjectCalisthenics.Files.FunctionLength rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 - Update slevomat/coding-standard from v6 to v7
 - Update squizlabs/php_codesniffer from v3.5 to v3.6
+- Replace the deprecated `ObjectCalisthenics.Files.FunctionLength` rule by `SlevomatCodingStandard.Files.FunctionLength`
 
 ## [21.0.0] - 2021-03-09
 ### Removed

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -60,11 +60,6 @@
 
     <!-- This block should be ordered alphabetically -->
     <!-- 3rd party -->
-    <rule ref="ObjectCalisthenics.Files.FunctionLength">
-        <properties>
-            <property name="maxLength" value="25"/>
-        </properties>
-    </rule>
     <rule ref="ObjectCalisthenics.Metrics.MaxNestingLevel">
         <properties>
             <property name="maxNestingLevel" value="3"/>
@@ -90,6 +85,11 @@
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireShortTernaryOperator"/>
+    <rule ref="SlevomatCodingStandard.Files.FunctionLength">
+        <properties>
+            <property name="maxLinesLength" value="25"/>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.Files.LineLength">
         <properties>
             <property name="lineLengthLimit" value="120"/>


### PR DESCRIPTION
This PR replaces the deprecated `ObjectCalisthenics.Files.FunctionLength` rule by `SlevomatCodingStandard.Files.FunctionLength`.

Given the following class:

```php
<?php

declare(strict_types=1);

namespace Test;

class TooLongFunction
{
    public function foo(): void
    {
        echo 'line 1';
        echo 'line 2';
        echo 'line 3';
        echo 'line 4';
        echo 'line 5';
        echo 'line 6';
        echo 'line 7';
        echo 'line 8';
        echo 'line 9';
        echo 'line 10';
        echo 'line 11';
        echo 'line 12';
        echo 'line 13';
        echo 'line 14';
        echo 'line 15';
        echo 'line 16';
        echo 'line 17';
        echo 'line 18';
        echo 'line 19';
        echo 'line 20';
        echo 'line 21';
        echo 'line 22';
        echo 'line 23';
        echo 'line 24';
        echo 'line 25';
    }
}
```

Previously the phpcs tool would generate the following output:

```
------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------------------------------------
 9 | ERROR | Your function is too long. Currently using 26 lines. Can be up to 25 lines.
   |       | (ObjectCalisthenics.Files.FunctionLength.ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff)
------------------------------------------------------------------------------------------------------------------------------------------------------
```

In this PR the `phpcs` tool generates the following output:

```
------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------------------------------------
 9 | ERROR | Your function is too long. Currently using 26 lines. Can be up to 25 lines.
   |       | (SlevomatCodingStandard.Files.FunctionLength.FunctionLength)
------------------------------------------------------------------------------------------------------------------------------------------------------
```

Note that the off-by-one error in the original rule is still present in the new rule.