### PR TITLE
Remove object-calisthenics/phpcs-calisthenics-rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Replace the deprecated `ObjectCalisthenics.Files.FunctionLength` rule by `SlevomatCodingStandard.Functions.FunctionLength`
 - Replace the deprecated `ObjectCalisthenics.Metrics.MaxNestingLevel` rule by `Generic.Metrics.NestingLevel`
+- Replace the deprecated `ObjectCalisthenics.Metrics.PropertyPerClassLimit` rule by `ISAAC.Classes.PropertyPerClassLimit`
 - Update slevomat/coding-standard from v6 to v7
 - Update squizlabs/php_codesniffer from v3.5 to v3.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update squizlabs/php_codesniffer from v3.5 to v3.6
 
 ### Removed
+- Removed object-calisthenics/phpcs-calisthenics-rules
 - Removed explicit reference to ISAAC rules (the rules added by this packages are included automatically)
 
 ## [21.0.0] - 2021-03-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace the deprecated `ObjectCalisthenics.Files.FunctionLength` rule by `SlevomatCodingStandard.Functions.FunctionLength`
 - Replace the deprecated `ObjectCalisthenics.Metrics.MaxNestingLevel` rule by `Generic.Metrics.NestingLevel`
 - Replace the deprecated `ObjectCalisthenics.Metrics.PropertyPerClassLimit` rule by `ISAAC.Classes.PropertyPerClassLimit`
+- Replace the deprecated `ObjectCalisthenics.Metrics.MethodPerClassLimit` rule by `ISAAC.Classes.MethodPerClassLimit`
 - Update slevomat/coding-standard from v6 to v7
 - Update squizlabs/php_codesniffer from v3.5 to v3.6
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
         "object-calisthenics/phpcs-calisthenics-rules": "^3.5",
-        "slevomat/coding-standard": "7.0.7 as 6.4.1",
+        "slevomat/coding-standard": "7.0.9 as 6.4.1",
         "squizlabs/php_codesniffer": "^3.6.0",
         "phpcompatibility/php-compatibility": "^9.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
     "require": {
         "php": "~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-        "object-calisthenics/phpcs-calisthenics-rules": "^3.5",
-        "slevomat/coding-standard": "7.0.9 as 6.4.1",
+        "slevomat/coding-standard": "^7.0.9",
         "squizlabs/php_codesniffer": "^3.6.0",
         "phpcompatibility/php-compatibility": "^9.3"
     },

--- a/src/Standards/ISAAC/Sniffs/Classes/MethodPerClassLimitSniff.php
+++ b/src/Standards/ISAAC/Sniffs/Classes/MethodPerClassLimitSniff.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IsaacCodingStandard\Standards\ISAAC\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\FunctionHelper;
+use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+
+use function count;
+use function sprintf;
+
+use const T_ANON_CLASS;
+use const T_CLASS;
+use const T_FUNCTION;
+use const T_INTERFACE;
+use const T_TRAIT;
+
+class MethodPerClassLimitSniff implements Sniff
+{
+    public const CODE_METHOD_PER_CLASS_LIMIT = 'MethodPerClassLimit';
+
+    public const ERROR_MESSAGE = '%s has too many methods: %d. Can be up to %d methods.';
+
+    /** @var int */
+    //phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
+    public $maxMethodCount = 10;
+
+    /**
+     * @return array<int, (int|string)>
+     */
+    public function register(): array
+    {
+        return [T_CLASS, T_ANON_CLASS, T_TRAIT, T_INTERFACE];
+    }
+
+    /**
+     * @param File $phpcsFile
+     * @param int $classPointer
+     */
+    public function process(File $phpcsFile, $classPointer): void
+    {
+        $maxMethodCount = SniffSettingsHelper::normalizeInteger($this->maxMethodCount);
+        $numberOfMethods = count($this->getMethodPointers($phpcsFile, $classPointer));
+        if ($numberOfMethods <= $maxMethodCount) {
+            return;
+        }
+        $errorMessage = sprintf(
+            self::ERROR_MESSAGE,
+            $phpcsFile->getTokens()[$classPointer]['content'],
+            $numberOfMethods,
+            $maxMethodCount
+        );
+        $phpcsFile->addError($errorMessage, $classPointer, self::CODE_METHOD_PER_CLASS_LIMIT);
+    }
+
+    /**
+     * @param File $phpcsFile
+     * @param int $classPointer
+     * @return int[]
+     */
+    protected function getMethodPointers(File $phpcsFile, int $classPointer): array
+    {
+        $classToken = $phpcsFile->getTokens()[$classPointer];
+        $scopeOpenerPointer = $classToken['scope_opener'];
+        $scopeCloserPointer = $classToken['scope_closer'];
+        $methodPointers = [];
+        $functionPointers =
+            TokenHelper::findNextAll($phpcsFile, T_FUNCTION, $scopeOpenerPointer + 1, $scopeCloserPointer);
+        foreach ($functionPointers as $functionPointer) {
+            if (!FunctionHelper::isMethod($phpcsFile, $functionPointer)) {
+                continue;
+            }
+            if (FunctionHelper::findClassPointer($phpcsFile, $functionPointer) !== $classPointer) {
+                continue;
+            }
+            $methodPointers[] = $functionPointer;
+        }
+        return $methodPointers;
+    }
+}

--- a/src/Standards/ISAAC/Sniffs/Classes/PropertyPerClassLimitSniff.php
+++ b/src/Standards/ISAAC/Sniffs/Classes/PropertyPerClassLimitSniff.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IsaacCodingStandard\Standards\ISAAC\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\PropertyHelper;
+use SlevomatCodingStandard\Helpers\ScopeHelper;
+use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+
+use function count;
+use function sprintf;
+
+use const T_ANON_CLASS;
+use const T_CLASS;
+use const T_TRAIT;
+use const T_VARIABLE;
+
+class PropertyPerClassLimitSniff implements Sniff
+{
+    public const CODE_PROPERTY_PER_CLASS_LIMIT = 'PropertyPerClassLimit';
+
+    public const ERROR_MESSAGE = '%s has too many properties: %d. Can be up to %d properties.';
+
+    /** @var int */
+    //phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
+    public $maxPropertyCount = 10;
+
+    /**
+     * @return array<int, (int|string)>
+     */
+    public function register(): array
+    {
+        return [T_CLASS, T_TRAIT, T_ANON_CLASS];
+    }
+
+    /**
+     * @param File $phpcsFile
+     * @param int $classPointer
+     */
+    public function process(File $phpcsFile, $classPointer): void
+    {
+        $maxPropertyCount = SniffSettingsHelper::normalizeInteger($this->maxPropertyCount);
+        $numberOfProperties = count($this->getPropertyPointers($phpcsFile, $classPointer));
+        if ($numberOfProperties <= $maxPropertyCount) {
+            return;
+        }
+        $errorMessage = sprintf(
+            self::ERROR_MESSAGE,
+            $phpcsFile->getTokens()[$classPointer]['content'],
+            $numberOfProperties,
+            $maxPropertyCount
+        );
+        $phpcsFile->addError($errorMessage, $classPointer, self::CODE_PROPERTY_PER_CLASS_LIMIT);
+    }
+
+    /**
+     * @param File $phpcsFile
+     * @param int $classPointer
+     * @return int[]
+     */
+    protected function getPropertyPointers(File $phpcsFile, int $classPointer): array
+    {
+        $classToken = $phpcsFile->getTokens()[$classPointer];
+        $scopeOpenerPointer = $classToken['scope_opener'];
+        $scopeCloserPointer = $classToken['scope_closer'];
+        $propertyPointers = [];
+        $variablePointers =
+            TokenHelper::findNextAll($phpcsFile, T_VARIABLE, $scopeOpenerPointer + 1, $scopeCloserPointer);
+        foreach ($variablePointers as $variablePointer) {
+            if (!PropertyHelper::isProperty($phpcsFile, $variablePointer)) {
+                continue;
+            }
+            if (!ScopeHelper::isInSameScope($phpcsFile, $classPointer, $variablePointer)) {
+                continue;
+            }
+            $propertyPointers[] = $variablePointer;
+        }
+        return $propertyPointers;
+    }
+}

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -65,11 +65,6 @@
 
     <!-- This block should be ordered alphabetically -->
     <!-- 3rd party -->
-    <rule ref="ObjectCalisthenics.Metrics.MethodPerClassLimit">
-        <properties>
-            <property name="maxCount" value="10"/>
-        </properties>
-    </rule>
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
     <rule ref="SlevomatCodingStandard.Classes.EmptyLinesAroundClassBraces">
         <properties>

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -70,11 +70,6 @@
             <property name="maxCount" value="10"/>
         </properties>
     </rule>
-    <rule ref="ObjectCalisthenics.Metrics.PropertyPerClassLimit">
-        <properties>
-            <property name="maxCount" value="10"/>
-        </properties>
-    </rule>
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
     <rule ref="SlevomatCodingStandard.Classes.EmptyLinesAroundClassBraces">
         <properties>

--- a/tests/CodeSnifferRunner.php
+++ b/tests/CodeSnifferRunner.php
@@ -70,6 +70,7 @@ class CodeSnifferRunner
     public function sniff(string $fileName): CodeSnifferResults
     {
         $filePath = sprintf('%s%s', $this->path, $fileName);
+        $this->codeSniffer->config->sniffs = [$this->sniff];
         $ruleset = new Ruleset($this->codeSniffer->config);
 
         $file = new File($filePath, $ruleset, $this->codeSniffer->config);

--- a/tests/Standards/ISAAC/Sniffs/Classes/Assets/MethodPerAnonymousClassLimitBad.inc
+++ b/tests/Standards/ISAAC/Sniffs/Classes/Assets/MethodPerAnonymousClassLimitBad.inc
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MethodPerAnonymousClassLimitBad;
+
+$tooManyMethods = new class {
+    public function method1(): void
+    {
+    }
+
+    public function method2(): void
+    {
+    }
+
+    public function method3(): void
+    {
+    }
+
+    public function method4(): void
+    {
+    }
+
+    public function method5(): void
+    {
+    }
+
+    public function method6(): void
+    {
+    }
+
+    public function method7(): void
+    {
+    }
+
+    public function method8(): void
+    {
+    }
+
+    public function method9(): void
+    {
+    }
+
+    public function method10(): void
+    {
+    }
+
+    public function method11(): void
+    {
+    }
+};

--- a/tests/Standards/ISAAC/Sniffs/Classes/Assets/MethodPerAnonymousClassLimitGood.inc
+++ b/tests/Standards/ISAAC/Sniffs/Classes/Assets/MethodPerAnonymousClassLimitGood.inc
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MethodPerAnonymousClassLimitGood;
+
+$maximumAmountOfMethods = new class {
+    /** @var string */
+    protected $foo = 'bar';
+
+    public function method1(): void
+    {
+    }
+
+    public function method2(): bool
+    {
+        return true;
+    }
+
+    public function method3(): int
+    {
+        return 1;
+    }
+
+    public function method4(): float
+    {
+        return 1.0;
+    }
+
+    public function method5(): string
+    {
+        return $this->foo;
+    }
+
+    /** @return int[] */
+    public function method6(): array
+    {
+        return [1, 2, 3];
+    }
+
+    /** @return null */
+    public function method7()
+    {
+        return null;
+    }
+
+    /** @return object */
+    protected function method8()
+    {
+        return new class {
+            public function getFoo(): string
+            {
+                return 'foo';
+            }
+        };
+    }
+
+    private function method9(): void
+    {
+        function nonClassMethodFunction(): void
+        {
+        }
+
+        nonClassMethodFunction();
+    }
+
+    /**
+     * @param mixed $x
+     * @return mixed
+     */
+    //phpcs:ignore Squiz.Scope.MethodScope
+    function method10($x)
+    {
+        return $x;
+    }
+};
+
+$anotherAnonymousClass = new class {
+    public function getBar(): string
+    {
+        return 'bar';
+    }
+};

--- a/tests/Standards/ISAAC/Sniffs/Classes/Assets/MethodPerClassLimitBad.inc
+++ b/tests/Standards/ISAAC/Sniffs/Classes/Assets/MethodPerClassLimitBad.inc
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MethodPerClassLimitBad;
+
+class TooManyMethods
+{
+    public function method1(): void
+    {
+    }
+
+    public function method2(): void
+    {
+    }
+
+    public function method3(): void
+    {
+    }
+
+    public function method4(): void
+    {
+    }
+
+    public function method5(): void
+    {
+    }
+
+    public function method6(): void
+    {
+    }
+
+    public function method7(): void
+    {
+    }
+
+    public function method8(): void
+    {
+    }
+
+    public function method9(): void
+    {
+    }
+
+    public function method10(): void
+    {
+    }
+
+    public function method11(): void
+    {
+    }
+}

--- a/tests/Standards/ISAAC/Sniffs/Classes/Assets/MethodPerClassLimitGood.inc
+++ b/tests/Standards/ISAAC/Sniffs/Classes/Assets/MethodPerClassLimitGood.inc
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MethodPerClassLimitGood;
+
+class MaximumAmountOfMethods
+{
+    /** @var string */
+    protected $foo = 'bar';
+
+    public function method1(): void
+    {
+    }
+
+    public function method2(): bool
+    {
+        return true;
+    }
+
+    public function method3(): int
+    {
+        return 1;
+    }
+
+    public function method4(): float
+    {
+        return 1.0;
+    }
+
+    public function method5(): string
+    {
+        return $this->foo;
+    }
+
+    /** @return int[] */
+    public function method6(): array
+    {
+        return [1, 2, 3];
+    }
+
+    /** @return null */
+    public function method7()
+    {
+        return null;
+    }
+
+    /** @return object */
+    protected function method8()
+    {
+        return new class {
+            public function getFoo(): string
+            {
+                return 'foo';
+            }
+        };
+    }
+
+    private function method9(): void
+    {
+        function nonClassMethodFunction(): void
+        {
+        }
+
+        nonClassMethodFunction();
+    }
+
+    /**
+     * @param mixed $x
+     * @return mixed
+     */
+    //phpcs:ignore Squiz.Scope.MethodScope
+    function method10($x)
+    {
+        return $x;
+    }
+}

--- a/tests/Standards/ISAAC/Sniffs/Classes/Assets/MethodPerInterfaceLimitBad.inc
+++ b/tests/Standards/ISAAC/Sniffs/Classes/Assets/MethodPerInterfaceLimitBad.inc
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MethodPerInterfaceLimitBad;
+
+interface TooManyMethods
+{
+    public function method1(): void;
+
+    public function method2(): void;
+
+    public function method3(): void;
+
+    public function method4(): void;
+
+    public function method5(): void;
+
+    public function method6(): void;
+
+    public function method7(): void;
+
+    public function method8(): void;
+
+    public function method9(): void;
+
+    public function method10(): void;
+
+    public function method11(): void;
+}

--- a/tests/Standards/ISAAC/Sniffs/Classes/Assets/MethodPerInterfaceLimitGood.inc
+++ b/tests/Standards/ISAAC/Sniffs/Classes/Assets/MethodPerInterfaceLimitGood.inc
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MethodPerClassLimitGood;
+
+interface MaximumAmountOfMethods
+{
+    public function method1(): void;
+
+    public function method2(): bool;
+
+    public function method3(): int;
+
+    public function method4(): float;
+
+    public function method5(): string;
+
+    /** @return int[] */
+    public function method6(): array;
+
+    /** @return null */
+    public function method7();
+
+    /** @return object */
+    public function method8();
+
+    public function method9(): void;
+
+    /**
+     * @param mixed $x
+     * @return mixed
+     */
+    //phpcs:ignore Squiz.Scope.MethodScope
+    function method10($x);
+}

--- a/tests/Standards/ISAAC/Sniffs/Classes/Assets/MethodPerTraitLimitBad.inc
+++ b/tests/Standards/ISAAC/Sniffs/Classes/Assets/MethodPerTraitLimitBad.inc
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MethodPerTraitLimitBad;
+
+trait TooManyMethods
+{
+    public function method1(): void
+    {
+    }
+
+    public function method2(): void
+    {
+    }
+
+    public function method3(): void
+    {
+    }
+
+    public function method4(): void
+    {
+    }
+
+    public function method5(): void
+    {
+    }
+
+    public function method6(): void
+    {
+    }
+
+    public function method7(): void
+    {
+    }
+
+    public function method8(): void
+    {
+    }
+
+    public function method9(): void
+    {
+    }
+
+    public function method10(): void
+    {
+    }
+
+    public function method11(): void
+    {
+    }
+}

--- a/tests/Standards/ISAAC/Sniffs/Classes/Assets/MethodPerTraitLimitGood.inc
+++ b/tests/Standards/ISAAC/Sniffs/Classes/Assets/MethodPerTraitLimitGood.inc
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MethodPerTraitLimitGood;
+
+trait MaximumAmountOfMethods
+{
+    /** @var string */
+    protected $foo = 'bar';
+
+    public function method1(): void
+    {
+    }
+
+    public function method2(): bool
+    {
+        return true;
+    }
+
+    public function method3(): int
+    {
+        return 1;
+    }
+
+    public function method4(): float
+    {
+        return 1.0;
+    }
+
+    public function method5(): string
+    {
+        return $this->foo;
+    }
+
+    /** @return int[] */
+    public function method6(): array
+    {
+        return [1, 2, 3];
+    }
+
+    /** @return null */
+    public function method7()
+    {
+        return null;
+    }
+
+    /** @return object */
+    protected function method8()
+    {
+        return new class {
+            public function getFoo(): string
+            {
+                return 'foo';
+            }
+        };
+    }
+
+    private function method9(): void
+    {
+        function nonClassMethodFunction(): void
+        {
+        }
+
+        nonClassMethodFunction();
+    }
+
+    /**
+     * @param mixed $x
+     * @return mixed
+     */
+    //phpcs:ignore Squiz.Scope.MethodScope
+    function method10($x)
+    {
+        return $x;
+    }
+}

--- a/tests/Standards/ISAAC/Sniffs/Classes/Assets/PropertyPerAnonymousClassLimitBad.inc
+++ b/tests/Standards/ISAAC/Sniffs/Classes/Assets/PropertyPerAnonymousClassLimitBad.inc
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PropertyPerAnonymousClassLimitBad;
+
+$tooManyProperties = new class {
+    /** @var mixed */
+    protected $property1;
+
+    /** @var mixed */
+    protected $property2;
+
+    /** @var mixed */
+    protected $property3;
+
+    /** @var mixed */
+    protected $property4;
+
+    /** @var mixed */
+    protected $property5;
+
+    /** @var mixed */
+    protected $property6;
+
+    /** @var mixed */
+    protected $property7;
+
+    /** @var mixed */
+    protected $property8;
+
+    /** @var mixed */
+    protected $property9;
+
+    /** @var mixed */
+    protected $property10;
+
+    /** @var mixed */
+    protected $property11;
+};

--- a/tests/Standards/ISAAC/Sniffs/Classes/Assets/PropertyPerAnonymousClassLimitGood.inc
+++ b/tests/Standards/ISAAC/Sniffs/Classes/Assets/PropertyPerAnonymousClassLimitGood.inc
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PropertyPerAnonymousClassLimitGood;
+
+$maximumAmountOfProperties = new class {
+    /** @var mixed */
+    protected $property1;
+
+    /** @var mixed */
+    protected $property2;
+
+    /** @var mixed */
+    protected $property3;
+
+    /** @var mixed */
+    protected $property4;
+
+    /** @var mixed */
+    protected $property5;
+
+    /** @var mixed */
+    protected $property6;
+
+    /** @var mixed */
+    protected $property7;
+
+    /** @var mixed */
+    protected $property8;
+
+    /** @var mixed */
+    protected $property9;
+
+    /** @var mixed */
+    protected $property10;
+
+    /** @return object */
+    protected function anonymousClassMethod()
+    {
+        return new class {
+            /** @var mixed */
+            protected $anonymousProperty1;
+        };
+    }
+};
+
+$anotherAnonymousClass = new class {
+    /** @var mixed */
+    protected $aProperty;
+};

--- a/tests/Standards/ISAAC/Sniffs/Classes/Assets/PropertyPerClassLimitBad.inc
+++ b/tests/Standards/ISAAC/Sniffs/Classes/Assets/PropertyPerClassLimitBad.inc
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PropertyPerClassLimitBad;
+
+class TooManyProperties
+{
+    /** @var mixed */
+    protected $property1;
+
+    /** @var mixed */
+    protected $property2;
+
+    /** @var mixed */
+    protected $property3;
+
+    /** @var mixed */
+    protected $property4;
+
+    /** @var mixed */
+    protected $property5;
+
+    /** @var mixed */
+    protected $property6;
+
+    /** @var mixed */
+    protected $property7;
+
+    /** @var mixed */
+    protected $property8;
+
+    /** @var mixed */
+    protected $property9;
+
+    /** @var mixed */
+    protected $property10;
+
+    /** @var mixed */
+    protected $property11;
+}

--- a/tests/Standards/ISAAC/Sniffs/Classes/Assets/PropertyPerClassLimitGood.inc
+++ b/tests/Standards/ISAAC/Sniffs/Classes/Assets/PropertyPerClassLimitGood.inc
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PropertyPerClassLimitGood;
+
+class MaximumAmountOfProperties
+{
+    /** @var mixed */
+    protected $property1;
+
+    /** @var mixed */
+    protected $property2;
+
+    /** @var mixed */
+    protected $property3;
+
+    /** @var mixed */
+    protected $property4;
+
+    /** @var mixed */
+    protected $property5;
+
+    /** @var mixed */
+    protected $property6;
+
+    /** @var mixed */
+    protected $property7;
+
+    /** @var mixed */
+    protected $property8;
+
+    /** @var mixed */
+    protected $property9;
+
+    /** @var mixed */
+    protected $property10;
+
+    /** @return object */
+    protected function anonymousClassMethod()
+    {
+        return new class {
+            /** @var mixed */
+            protected $anonymousProperty1;
+        };
+    }
+}

--- a/tests/Standards/ISAAC/Sniffs/Classes/Assets/PropertyPerTraitLimitBad.inc
+++ b/tests/Standards/ISAAC/Sniffs/Classes/Assets/PropertyPerTraitLimitBad.inc
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PropertyPerTraitLimitBad;
+
+trait TooManyProperties
+{
+    /** @var mixed */
+    protected $property1;
+
+    /** @var mixed */
+    protected $property2;
+
+    /** @var mixed */
+    protected $property3;
+
+    /** @var mixed */
+    protected $property4;
+
+    /** @var mixed */
+    protected $property5;
+
+    /** @var mixed */
+    protected $property6;
+
+    /** @var mixed */
+    protected $property7;
+
+    /** @var mixed */
+    protected $property8;
+
+    /** @var mixed */
+    protected $property9;
+
+    /** @var mixed */
+    protected $property10;
+
+    /** @var mixed */
+    protected $property11;
+}

--- a/tests/Standards/ISAAC/Sniffs/Classes/Assets/PropertyPerTraitLimitGood.inc
+++ b/tests/Standards/ISAAC/Sniffs/Classes/Assets/PropertyPerTraitLimitGood.inc
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PropertyPerClassLimitGood;
+
+trait MaximumAmountOfProperties
+{
+    /** @var mixed */
+    protected $property1;
+
+    /** @var mixed */
+    protected $property2;
+
+    /** @var mixed */
+    protected $property3;
+
+    /** @var mixed */
+    protected $property4;
+
+    /** @var mixed */
+    protected $property5;
+
+    /** @var mixed */
+    protected $property6;
+
+    /** @var mixed */
+    protected $property7;
+
+    /** @var mixed */
+    protected $property8;
+
+    /** @var mixed */
+    protected $property9;
+
+    /** @var mixed */
+    protected $property10;
+
+    /** @return object */
+    protected function anonymousClassMethod()
+    {
+        return new class {
+            /** @var mixed */
+            protected $anonymousProperty1;
+        };
+    }
+}

--- a/tests/Standards/ISAAC/Sniffs/Classes/MethodPerClassLimitSniffTest.php
+++ b/tests/Standards/ISAAC/Sniffs/Classes/MethodPerClassLimitSniffTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IsaacCodingStandard\Tests\Standards\ISAAC\Sniffs\Classes;
+
+use IsaacCodingStandard\Standards\ISAAC\Sniffs\Classes\MethodPerClassLimitSniff;
+use IsaacCodingStandard\Tests\BaseTestCase;
+use PHP_CodeSniffer\Exceptions\DeepExitException;
+
+use function sprintf;
+
+class MethodPerClassLimitSniffTest extends BaseTestCase
+{
+    /**
+     * @return void
+     * @throws DeepExitException
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->codeSnifferRunner
+            ->setSniff('ISAAC.Classes.MethodPerClassLimit')
+            ->setFolder(sprintf('%s/Assets/', __DIR__));
+    }
+
+    /** @dataProvider goodDataProvider */
+    public function testGood(string $fileName): void
+    {
+        $results = $this->codeSnifferRunner->sniff($fileName);
+        $errorCount = $results->getErrorCount();
+        self::assertSame(0, $errorCount, sprintf('expected no errors, got %d errors', $errorCount));
+    }
+
+    /** @dataProvider badDataProvider */
+    public function testBad(string $fileName, string $tokenName): void
+    {
+        $results = $this->codeSnifferRunner->sniff($fileName);
+        $errorCount = $results->getErrorCount();
+        self::assertSame(1, $errorCount, sprintf('expected 1 error, got %d errors', $errorCount));
+        foreach ($results->getAllErrorMessages() as $errorMessage) {
+            self::assertEquals(
+                sprintf(MethodPerClassLimitSniff::ERROR_MESSAGE, $tokenName, 11, 10),
+                $errorMessage
+            );
+        }
+    }
+
+    /** @return mixed[][] */
+    public function goodDataProvider(): array
+    {
+        return [
+            ['MethodPerClassLimitGood.inc', ],
+            ['MethodPerAnonymousClassLimitGood.inc', ],
+            ['MethodPerTraitLimitGood.inc', ],
+            ['MethodPerInterfaceLimitGood.inc', ],
+        ];
+    }
+
+    /** @return mixed[][] */
+    public function badDataProvider(): array
+    {
+        return [
+            ['MethodPerClassLimitBad.inc', 'class', ],
+            ['MethodPerAnonymousClassLimitBad.inc', 'class', ],
+            ['MethodPerTraitLimitBad.inc', 'trait', ],
+            ['MethodPerInterfaceLimitBad.inc', 'interface', ],
+        ];
+    }
+}

--- a/tests/Standards/ISAAC/Sniffs/Classes/PropertyPerClassLimitSniffTest.php
+++ b/tests/Standards/ISAAC/Sniffs/Classes/PropertyPerClassLimitSniffTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IsaacCodingStandard\Tests\Standards\ISAAC\Sniffs\Classes;
+
+use IsaacCodingStandard\Standards\ISAAC\Sniffs\Classes\PropertyPerClassLimitSniff;
+use IsaacCodingStandard\Tests\BaseTestCase;
+use PHP_CodeSniffer\Exceptions\DeepExitException;
+
+use function sprintf;
+
+class PropertyPerClassLimitSniffTest extends BaseTestCase
+{
+    /**
+     * @return void
+     * @throws DeepExitException
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->codeSnifferRunner
+            ->setSniff('ISAAC.Classes.PropertyPerClassLimit')
+            ->setFolder(sprintf('%s/Assets/', __DIR__));
+    }
+
+    /** @dataProvider goodDataProvider */
+    public function testGood(string $fileName): void
+    {
+        $results = $this->codeSnifferRunner->sniff($fileName);
+        $errorCount = $results->getErrorCount();
+        self::assertSame(0, $errorCount, sprintf('expected no errors, got %d errors', $errorCount));
+    }
+
+    /** @dataProvider badDataProvider */
+    public function testBad(string $fileName, string $tokenName): void
+    {
+        $results = $this->codeSnifferRunner->sniff($fileName);
+        $errorCount = $results->getErrorCount();
+        self::assertSame(1, $errorCount, sprintf('expected 1 error, got %d errors', $errorCount));
+        foreach ($results->getAllErrorMessages() as $errorMessage) {
+            self::assertEquals(
+                sprintf(PropertyPerClassLimitSniff::ERROR_MESSAGE, $tokenName, 11, 10),
+                $errorMessage
+            );
+        }
+    }
+
+    /** @return mixed[][] */
+    public function goodDataProvider(): array
+    {
+        return [
+            ['PropertyPerClassLimitGood.inc', ],
+            ['PropertyPerAnonymousClassLimitGood.inc', ],
+            ['PropertyPerTraitLimitGood.inc', ],
+        ];
+    }
+
+    /** @return mixed[][] */
+    public function badDataProvider(): array
+    {
+        return [
+            ['PropertyPerClassLimitBad.inc', 'class', ],
+            ['PropertyPerAnonymousClassLimitBad.inc', 'class', ],
+            ['PropertyPerTraitLimitBad.inc', 'trait', ],
+        ];
+    }
+}

--- a/tests/Standards/ISAAC/Sniffs/ControlStructures/DisallowNullCoalesceOperatorSniffTest.php
+++ b/tests/Standards/ISAAC/Sniffs/ControlStructures/DisallowNullCoalesceOperatorSniffTest.php
@@ -21,7 +21,7 @@ class DisallowNullCoalesceOperatorSniffTest extends BaseTestCase
         parent::setUp();
 
         $this->codeSnifferRunner
-            ->setSniff('ISAAC.ControlStructures.DisallowNullCoalesceOperatorSniff')
+            ->setSniff('ISAAC.ControlStructures.DisallowNullCoalesceOperator')
             ->setFolder(sprintf('%s/Assets/', __DIR__));
     }
 

--- a/tests/Standards/ISAAC/Sniffs/Namespaces/MultipleLinesPerUseSniffTest.php
+++ b/tests/Standards/ISAAC/Sniffs/Namespaces/MultipleLinesPerUseSniffTest.php
@@ -23,7 +23,7 @@ class MultipleLinesPerUseSniffTest extends BaseTestCase
         parent::setUp();
 
         $this->codeSnifferRunner
-            ->setSniff('ISAAC.Namespaces.MultipleLinesPerUseSniff')
+            ->setSniff('ISAAC.Namespaces.MultipleLinesPerUse')
             ->setFolder(sprintf('%s/Assets/', __DIR__));
     }
 


### PR DESCRIPTION
This PR removes the abandoned [object-calisthenics/phpcs-calisthenics-rules package](https://github.com/object-calisthenics/phpcs-calisthenics-rules) by offering a custom replacement for the rules that were in use:
* `ObjectCalisthenics.Metrics.PropertyPerClassLimit`: is replaced by `ISAAC.Classes.PropertyPerClassLimit`
* `ObjectCalisthenics.Metrics.MethodPerClassLimit`: is replaced by `ISAAC.Classes.MethodPerClassLimit`

Both rules have been completely reimplemented, and have support for anonymous classes. Also, issues have been resolved where global functions and anonymous class methods/properties were counted incorrectly when they were defined inside a class.