### PR TITLE
Add sniff to make nullable type required for parameters with default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add sniff to require nullable type for parameters with a default null value.
+`SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue`
 
 ## [23.0.0] - 2021-08-04
 ### Added

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -117,6 +117,7 @@
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint"/>
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint"/>


### PR DESCRIPTION
Add `SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue ` sniff. https://github.com/slevomat/coding-standard#slevomatcodingstandardtypehintsnullabletypefornulldefaultvalue-

```php
// Disallow:
public function foo(string $value = null): void {}

// Allow:
public function foo(?string $value = null): void {}
```