### PR TITLE
Remove the `Generic.CodeAnalysis.UselessOverridingMethod` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+### Removed
+- Remove the `Generic.CodeAnalysis.UselessOverridingMethod` rule
+
 ## [25.0.0] - 2021-11-05
 ### Added
 - Add GitHub Action

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -25,7 +25,6 @@
     <rule ref="Generic.CodeAnalysis.JumbledIncrementer"/>
     <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
     <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
-    <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
     <rule ref="Generic.Commenting.Fixme"/>
     <rule ref="Generic.Commenting.Todo"/>
     <rule ref="Generic.Files.LineEndings"/>


### PR DESCRIPTION
The `Generic.CodeAnalysis.UselessOverridingMethod` rule generates false positives for a number of common scenarios where the signature of a parent method should be changed, but the implementation should stay the same. Especially for the case where parent methods have _implicit_ argument/return types, it should be encouraged to make these _explicit_ in the child method; however, the use of the `Generic.CodeAnalysis.UselessOverridingMethod` rule discourages this practice by generating warnings.

This PR removes the use of the `Generic.CodeAnalysis.UselessOverridingMethod` rule from the ISAAC PHP_CodeSniffer Standard.

In the following, two typical examples are provided.

**Type narrowing**

Consider the following PHP code:

```php
<?php

declare(strict_types=1);

namespace MyNamespace;

use ArrayIterator;
use stdClass;

class StdClassCollection extends ArrayIterator
{
    public function __construct(stdClass ...$stdObjects)
    {
        parent::__construct($stdObjects);
    }

    public function key(): int
    {
        return parent::key();
    }

    public function current(): stdClass
    {
        return parent::current();
    }
}
```

This generates the following warnings:

```
-----------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 3 WARNINGS AFFECTING 3 LINES
-----------------------------------------------------------------------------------------------------------------
 12 | WARNING | Possible useless method overriding detected
    |         | (Generic.CodeAnalysis.UselessOverridingMethod.Found)
 17 | WARNING | Possible useless method overriding detected
    |         | (Generic.CodeAnalysis.UselessOverridingMethod.Found)
 22 | WARNING | Possible useless method overriding detected
    |         | (Generic.CodeAnalysis.UselessOverridingMethod.Found)
-----------------------------------------------------------------------------------------------------------------
```

See PHP_CodeSniffer issue [3467](https://github.com/squizlabs/PHP_CodeSniffer/issues/3467) for details.

**Changing default values**

Consider the following PHP code:

```php
<?php

declare(strict_types=1);

namespace MyNamespace;

use Exception;

class MyException extends Exception
{
    public function __construct(string $message = 'My Message', int $code = 123)
    {
        parent::__construct($message, $code);
    }
}
```

The generates the following warning:

```
-----------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
-----------------------------------------------------------------------------------------------------------------
 11 | WARNING | Possible useless method overriding detected
    |         | (Generic.CodeAnalysis.UselessOverridingMethod.Found)
-----------------------------------------------------------------------------------------------------------------
```

See PHP_CodeSniffer issues [519](https://github.com/squizlabs/PHP_CodeSniffer/issues/519) and [3035](https://github.com/squizlabs/PHP_CodeSniffer/issues/3035) for details.
