### PR TITLE
Remove explicit inclusion of the `PSR12.Operators.OperatorSpacing` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Remove explicit inclusion of the `PSR12.Operators.OperatorSpacing` rule
 
 ## [25.1.0] - 2021-12-08
 ### Removed

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -57,7 +57,6 @@
     </rule>
     <rule ref="Generic.PHP.Syntax"/>
     <rule ref="MySource.PHP.GetRequestData"/>
-    <rule ref="PSR12.Operators.OperatorSpacing"/>
 
     <!-- ISAAC -->
     <!-- all src/Standards/ISAAC/Sniffs/*/*Sniff.php rules are included automatically -->


### PR DESCRIPTION
This PR removes explicit inclusion of the `PSR12.Operators.OperatorSpacing` rule.

It is already included via the `PSR12` ruleset:

```
$ vendor/bin/phpcs --standard=PSR12 -e | grep PSR12.Operators.OperatorSpacing
  PSR12.Operators.OperatorSpacing
```