### PR TITLE
Add sniff to disallow unused variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `SlevomatCodingStandard.Variables.UnusedVariable` rule
+
 ### Changed
 - Change the `Generic.PHP.ForbiddenFunctions` array value into a more readable and expandable form
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-        "slevomat/coding-standard": "^7.0.9",
+        "slevomat/coding-standard": "^7.0.19",
         "squizlabs/php_codesniffer": "^3.6.0",
         "phpcompatibility/php-compatibility": "^9.3"
     },

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -124,6 +124,11 @@
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint"/>
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/>
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint"/>
+    <rule ref="SlevomatCodingStandard.Variables.UnusedVariable">
+        <properties>
+            <property name="ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach" value="true"/>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint"/>
     <rule ref="Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps"/>
     <rule ref="Squiz.NamingConventions.ValidVariableName.NotCamelCaps"/>


### PR DESCRIPTION
This PR adds the `SlevomatCodingStandard.Variables.UnusedVariable` sniff, which detects unused variables. See the [unusedVariableErrors.php](https://github.com/slevomat/coding-standard/blob/7.0.19/tests/Sniffs/Variables/data/unusedVariableErrors.php) test file for a number of examples that are detected by this tool.

For key/value pairs in a foreach statement where only the key is used, no violation is reported when the value is unused (this required setting the `ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach` property to `true`).

So the following file does not generate an error:

```php
<?php

declare(strict_types=1);

function keystoupper(array $values): array
{
    $result = [];
    foreach ($values as $key => $value) {
        $result[] = strtoupper($key);
    }
    return $result;
}
```

Note that the following still generates an error, because the key is unused:

```php
<?php

declare(strict_types=1);

function strstoupper(array $values): array
{
    $result = [];
    foreach ($values as $key => $value) {
        $result[] = strtoupper($value);
    }
    return $result;
}
```

The following error is reported:

```
FILE: /path/to/file.php
----------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------------------------------------
 8 | ERROR | Unused variable $key.
   |       | (SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable)
----------------------------------------------------------------------------------------------------
```

NB This PR upgrades the Slevomat Coding Standard to v7.0.19, which fixes a few issues in this sniff ([#1320](https://github.com/slevomat/coding-standard/issues/1320) and [#1321](https://github.com/slevomat/coding-standard/issues/1321)).