### PR TITLE
Disallow all superglobals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Disallow all superglobals by replacing the `MySource.PHP.GetRequestData` rule by the more complete `SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable` rule
 - Change the `Generic.PHP.ForbiddenFunctions` array value into a more readable and expandable form
 
 ### Removed

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -59,7 +59,6 @@
         </properties>
     </rule>
     <rule ref="Generic.PHP.Syntax"/>
-    <rule ref="MySource.PHP.GetRequestData"/>
 
     <!-- ISAAC -->
     <!-- all src/Standards/ISAAC/Sniffs/*/*Sniff.php rules are included automatically -->
@@ -125,6 +124,7 @@
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/>
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint"/>
     <rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint"/>
+    <rule ref="SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable"/>
     <rule ref="Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps"/>
     <rule ref="Squiz.NamingConventions.ValidVariableName.NotCamelCaps"/>
     <rule ref="Squiz.Strings.DoubleQuoteUsage.ContainsVar"/>


### PR DESCRIPTION
This PR replaces the `MySource.PHP.GetRequestData` rule by the more complete `SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable` rule, such that not only `$_GET`, `$_POST`, `$_FILES` and `$_REQUEST` are disallowed, but also `$_COOKIE`, `$_SESSION`, `$_ENV` and `$GLOBALS`.

This also resolves the issue that the errors message mentions a non-existing `Security::getRequestData` method.

Consider the following code:

```php
<?php

declare(strict_types=1);

print_r($GLOBALS);
print_r($_SERVER);
print_r($_GET);
print_r($_POST);
print_r($_FILES);
print_r($_COOKIE);
print_r($_SESSION);
print_r($_REQUEST);
print_r($_ENV);
```

This currently results in the following 4 errors:

```
FILE: /path/to/file.php
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 4 ERRORS AFFECTING 4 LINES
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
  7 | ERROR | The $_GET super global must not be accessed directly; use Security::getRequestData() instead (MySource.PHP.GetRequestData.SuperglobalAccessed)
  8 | ERROR | The $_POST super global must not be accessed directly; use Security::getRequestData() instead
    |       | (MySource.PHP.GetRequestData.SuperglobalAccessed)
  9 | ERROR | The $_FILES super global must not be accessed directly; use Security::getRequestData() instead
    |       | (MySource.PHP.GetRequestData.SuperglobalAccessed)
 12 | ERROR | The $_REQUEST super global must not be accessed directly; use Security::getRequestData() instead
    |       | (MySource.PHP.GetRequestData.SuperglobalAccessed)
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
```

In this PR, this is changed to the following 8 errors:

```
FILE: /Users/aad/Code/isaac/github/php-code-sniffer-standard/tests/superglobals.php
-------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 9 ERRORS AFFECTING 9 LINES
-------------------------------------------------------------------------------------------------------------------------------------------------------
  5 | ERROR | Use of super global variable is disallowed.
    |       | (SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable.DisallowedSuperGlobalVariable)
  6 | ERROR | Use of super global variable is disallowed.
    |       | (SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable.DisallowedSuperGlobalVariable)
  7 | ERROR | Use of super global variable is disallowed.
    |       | (SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable.DisallowedSuperGlobalVariable)
  8 | ERROR | Use of super global variable is disallowed.
    |       | (SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable.DisallowedSuperGlobalVariable)
  9 | ERROR | Use of super global variable is disallowed.
    |       | (SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable.DisallowedSuperGlobalVariable)
 10 | ERROR | Use of super global variable is disallowed.
    |       | (SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable.DisallowedSuperGlobalVariable)
 11 | ERROR | Use of super global variable is disallowed.
    |       | (SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable.DisallowedSuperGlobalVariable)
 12 | ERROR | Use of super global variable is disallowed.
    |       | (SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable.DisallowedSuperGlobalVariable)
 13 | ERROR | Use of super global variable is disallowed.
    |       | (SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable.DisallowedSuperGlobalVariable)
-------------------------------------------------------------------------------------------------------------------------------------------------------
```