### PR TITLE
Remove explicit reference to the `Generic.Files.LineEndings` sniff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Removed
 - Remove explicit inclusion of the `PSR12.Operators.OperatorSpacing` rule
+- Remove explicit inclusion of the `Generic.Files.LineEndings` rule
 
 ## [25.1.0] - 2021-12-08
 ### Removed

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -27,7 +27,6 @@
     <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
     <rule ref="Generic.Commenting.Fixme"/>
     <rule ref="Generic.Commenting.Todo"/>
-    <rule ref="Generic.Files.LineEndings"/>
     <rule ref="Generic.Formatting.MultipleStatementAlignment">
         <properties>
             <property name="maxPadding" value="1" />


### PR DESCRIPTION
This PR removes the explicit inclusion of the `Generic.Files.LineEndings` sniff.

This is unnecessary, as this sniff is already included via the `PSR12` ruleset:

```xml
    <!-- All PHP files MUST use the Unix LF (linefeed) line ending only. -->
    <rule ref="Generic.Files.LineEndings">
        <properties>
            <property name="eolChar" value="\n"/>
        </properties>
    </rule>
```

Note that the `PSR12` ruleset explicitly specifies a value for the `eolChar` property, whereas the `ISAAC` ruleset did not. However, this doesn't make a difference, since the `\n` value is the default value of that property.