### PR TITLE
Remove explicit reference to the `Squiz.WhiteSpace.SuperfluousWhitespace` sniff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Removed
 - Remove explicit inclusion of the `PSR12.Operators.OperatorSpacing` rule
+- Remove explicit inclusion of the `Squiz.WhiteSpace.SuperfluousWhitespace` rule
 
 ## [25.1.0] - 2021-12-08
 ### Removed

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -138,9 +138,4 @@
             <property name="ignoreNewlines" value="true" />
         </properties>
     </rule>
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
-        <properties>
-            <property name="ignoreBlankLines" value="false"/>
-        </properties>
-    </rule>
 </ruleset>


### PR DESCRIPTION
This PR removes the explicit inclusion of the `Squiz.WhiteSpace.SuperfluousWhitespace` sniff.

This is unnecessary, as this sniff is already included via the `PSR12` ruleset:

```xml
    <!-- There MUST NOT be trailing whitespace at the end of lines.
    Blank lines MAY be added to improve readability and to indicate related blocks of code except where explicitly forbidden. -->
    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.StartFile">
        <severity>0</severity>
    </rule>
    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EndFile">
        <severity>0</severity>
    </rule>
    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines">
        <severity>0</severity>
    </rule>

```

Note that the `ISAAC` ruleset explicitly specified a value for the `ignoreBlankLines` property, whereas the `PSR12` ruleset does not. However, this doesn't make a difference, since the `false` value is the default value of that property.