### PR TITLE
Add the `Generic.PHP.BacktickOperator` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add the `Generic.PHP.BacktickOperator` rule
+
 ### Changed
 - Change the `Generic.PHP.ForbiddenFunctions` array value into a more readable and expandable form
 

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -49,6 +49,7 @@
             <property name="absoluteNestingLevel" value="3"/>
         </properties>
     </rule>
+    <rule ref="Generic.PHP.BacktickOperator"/>
     <rule ref="Generic.PHP.ForbiddenFunctions">
         <properties>
             <property name="forbiddenFunctions" type="array">


### PR DESCRIPTION
This PR disallows the use of the backtick operator by adding the `Generic.PHP.BacktickOperator` rule.

Consider the following confusing PHP code:

```php
<?php

declare(strict_types=1);

echo '`ls`';
echo `'ls'`;
```

With the current ruleset, this does not report any error.

After merging this PR, the following error is reported:

```
FILE: /path/to/file.php
--------------------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 1 LINE
--------------------------------------------------------------------------------------------
 6 | ERROR | Use of the backtick operator is forbidden
   |       | (Generic.PHP.BacktickOperator.Found)
 6 | ERROR | Use of the backtick operator is forbidden
   |       | (Generic.PHP.BacktickOperator.Found)
--------------------------------------------------------------------------------------------
```

To repair this error, you can use the `shell_exec` function instead, that does not require a potentially confusing syntax:

```php
<?php

declare(strict_types=1);

echo '`ls`';
echo shell_exec('ls');
```