### PR TITLE
Add `ISAAC.ControlStructures.DisallowGotoOperator` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `ISAAC.ControlStructures.DisallowGotoOperator` rule
+
 ### Changed
 - Change the `Generic.PHP.ForbiddenFunctions` array value into a more readable and expandable form
 

--- a/src/Standards/ISAAC/Sniffs/ControlStructures/DisallowGotoOperatorSniff.php
+++ b/src/Standards/ISAAC/Sniffs/ControlStructures/DisallowGotoOperatorSniff.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IsaacCodingStandard\Standards\ISAAC\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+use const T_GOTO;
+
+class DisallowGotoOperatorSniff implements Sniff
+{
+    public const ERROR_CODE = 'Found';
+
+    public const ERROR_MESSAGE = 'Use of the goto operator is disallowed.';
+
+    /**
+     * @return array<int>
+     */
+    public function register(): array
+    {
+        return [
+            T_GOTO,
+        ];
+    }
+
+    /**
+     * @param File $phpcsFile
+     * @param int $stackPtr
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $phpcsFile->addError(self::ERROR_MESSAGE, $stackPtr, self::ERROR_CODE);
+    }
+}

--- a/tests/Standards/ISAAC/Sniffs/ControlStructures/Assets/DisallowGotoOperatorSniff.inc
+++ b/tests/Standards/ISAAC/Sniffs/ControlStructures/Assets/DisallowGotoOperatorSniff.inc
@@ -1,0 +1,6 @@
+<?php
+
+declare(strict_types=1);
+
+l10: print mb_chr(0x2571 + random_int(0, 1));
+goto l10;

--- a/tests/Standards/ISAAC/Sniffs/ControlStructures/DisallowGotoOperatorSniffTest.php
+++ b/tests/Standards/ISAAC/Sniffs/ControlStructures/DisallowGotoOperatorSniffTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IsaacCodingStandard\Tests\Standards\ISAAC\Sniffs\ControlStructures;
+
+use IsaacCodingStandard\Standards\ISAAC\Sniffs\ControlStructures\DisallowGotoOperatorSniff;
+use IsaacCodingStandard\Tests\BaseTestCase;
+use PHP_CodeSniffer\Exceptions\DeepExitException;
+
+use function sprintf;
+
+class DisallowGotoOperatorSniffTest extends BaseTestCase
+{
+    /**
+     * @return void
+     * @throws DeepExitException
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->codeSnifferRunner
+            ->setSniff('ISAAC.ControlStructures.DisallowGotoOperator')
+            ->setFolder(sprintf('%s/Assets/', __DIR__));
+    }
+
+    /**
+     * @return void
+     * @throws DeepExitException
+     */
+    public function testSniff(): void
+    {
+        $results = $this->codeSnifferRunner->sniff('DisallowGotoOperatorSniff.inc');
+
+        self::assertSame(1, $results->getErrorCount());
+        self::assertSame(0, $results->getWarningCount());
+
+        $errorMessages = $results->getAllErrorMessages();
+        self::assertCount(1, $errorMessages);
+
+        foreach ($errorMessages as $errorMessage) {
+            self::assertEquals(DisallowGotoOperatorSniff::ERROR_MESSAGE, $errorMessage);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a rule that disallows the `goto` operator, which is [considered bad practice](https://en.wikipedia.org/wiki/Goto#Criticism).

Consider the following PHP code, inspired by [10 PRINT](https://10print.org/):

```php
<?php

declare(strict_types=1);

l10: print mb_chr(0x2571 + random_int(0, 1));
goto l10;
```

This currently does not generate any error.

After merging this PR, the following error is generated:

```
FILE: /path/to/10print.php
----------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------------------------------------------
 6 | ERROR | Use of the goto operator is disallowed.
   |       | (ISAAC.ControlStructures.DisallowGotoOperator.Found)
----------------------------------------------------------------------------------------------------------
```