### PR TITLE
COMPOSER: Modify php version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Change the php version in composer.json into an easier to maintain form
 - Change the `Generic.PHP.ForbiddenFunctions` array value into a more readable and expandable form
 
 ### Removed

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "type": "phpcodesniffer-standard",
     "license": "MIT",
     "require": {
-        "php": "~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0",
+        "php": ">=7.3.0 <8.2.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
         "slevomat/coding-standard": "^7.0.9",
         "squizlabs/php_codesniffer": "^3.6.0",


### PR DESCRIPTION
Currently the php versioning looks as follows in the [composer.json](https://github.com/isaaceindhoven/php-code-sniffer-standard/blob/develop/composer.json#L17) file: 

`"php": "~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0"`

Expanding this according to [composer's v & c](https://getcomposer.org/doc/articles/versions.md#tilde-version-range-) this should translates to:

`>= 7.3.0 < 7.4.0 || >= 7.4.0 < 7.5.0 || >= 8.0.0 < 8.1.0 || >= 8.1.0 < 8.2.0`

The proposed change to the version is _not_ exactly equivalent but should make it easier to update and include future PHP versions.

Please let me know if there is anything I overlooked or if this is an unwanted change!