### PR TITLE
RULESET: Add `SlevomatCodingStandard.Classes.ModernClassNameReference`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add the `SlevomatCodingStandard.Classes.ModernClassNameReference` rule
 
 ## [26.0.0] - 2022-04-19
 ### Added

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -73,6 +73,7 @@
             <property name="linesCountBeforeClosingBrace" value="0"/>
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireShortTernaryOperator"/>


### PR DESCRIPTION
This PR disallows the use of different ways to obtain the class name of objects by adding the `SlevomatCodingStandard.Classes.ModernClassNameReference` rule.

Consider the following PHP code:

```php
<?php

declare(strict_types=1);

namespace App;

use function get_class;

class Foo
{
    public function equals(object $object): bool
    {
        // Some initial checks

        if (get_class($object) !== get_class($this)) {
            return false;
        }

        // Any additional checks
    }
}
```

With the current ruleset, this does not report any error.

After merging this PR, the following error is reported:

```
FILE: /src/Foo.php
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 16 | ERROR | [x] Class name referenced via call of function get_class().
    |       |     (SlevomatCodingStandard.Classes.ModernClassNameReference.ClassNameReferencedViaFunctionCall)
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

Repairing this error in PHP 7.4 will result in the following:
```php
<?php

declare(strict_types=1);

namespace App;

use function get_class;

class Foo
{
    public function equals(object $object): bool
    {
        // Some initial checks

        if (get_class($object) !== static::class) {
            return false;
        }

        // Any additional checks
    }
}
```

And in PHP 8.0 or higher, the [class name literal](https://wiki.php.net/rfc/class_name_literal_on_object) is usable on objects, which will result in:
```php
<?php

declare(strict_types=1);

namespace App;

class Foo
{
    public function equals(object $object): bool
    {
        // Some initial checks

        if ($object::class !== static::class) {
            return false;
        }

        // Any additional checks
    }
}
```