### PR TITLE
FORBIDDEN FUNCTIONS: Add `serialize()` and `unserialize()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `serialize()` and `unzerialize()` to forbidden functions
 
 ## [26.0.0] - 2022-04-19
 ### Added

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -56,6 +56,8 @@
                 <element key="empty" value="null"/>
                 <element key="isset" value="null"/>
                 <element key="is_null" value="null"/>
+                <element key="serialize" value="json_encode"/>
+                <element key="unserialize" value="json_decode"/>
             </property>
         </properties>
     </rule>


### PR DESCRIPTION
This PR forbids the use of two considered [non-secure](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/security/non-secure-functions.html) functions, `serialize()` and `unserialize()`.

> The vulnerability occurs when user-supplied input is not properly sanitized before being passed to the unserialize() PHP function. Since PHP allows object serialization, attackers could pass ad-hoc serialized strings to a vulnerable unserialize() call, resulting in an arbitrary PHP object(s) injection into the application scope.

Take the following PHP script as an example:
```php
<?php

declare(strict_types=1);

class Example
{
    private string $cacheFile;

    public function __destruct()
    {
        $file = '/var/www/cache/tmp/' . $this->cacheFile;

        if (file_exists($file)) {
            @unlink($file);
        }
    }
}

$exampleObject = unserialize('O:7:"Example":1:{s:9:"cacheFile";s:15:"../../index.php";}');
serialize($exampleObject);
```
Using the step debugger shows that `Example::$cacheFile` holds the value: `'../../index.php'`, and `$file` will hold the value `"/var/www/cache/tmp/../../index.php"`. Thus, if this file were to exist it would be deleted from the file system, this is referred to as a [path traversal attack](https://owasp.org/www-community/attacks/Path_Traversal). 

Information and example taken from [owasp PHP Object Injection](https://owasp.org/www-community/vulnerabilities/PHP_Object_Injection).

With both `serialize()` and `unserialize()` added to the list of forbidden functions, the user would get the following error notification:
```shell
------------------------------------------------------------------------------------------------------------------------
 19 | ERROR   | The use of function unserialize() is forbidden (Generic.PHP.ForbiddenFunctions.Found)
 20 | ERROR   | The use of function serialize() is forbidden (Generic.PHP.ForbiddenFunctions.Found)
------------------------------------------------------------------------------------------------------------------------
```
The PHP documentation also reports a warning about `unserialize()` in its [documentation](https://www.php.net/manual/en/function.unserialize.php#refsect1-function.unserialize-description) and recommends to use `json_decode()` and `json_encode()` if serialized data has to be passed to the user.