### PR TITLE
FORBIDDEN FUNCTIONS: Add `eval()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `eval()` to forbidden functions
 
 ## [26.0.0] - 2022-04-19
 ### Added

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -56,6 +56,7 @@
                 <element key="empty" value="null"/>
                 <element key="isset" value="null"/>
                 <element key="is_null" value="null"/>
+                <element key="eval" value="null"/>
             </property>
         </properties>
     </rule>


### PR DESCRIPTION
This PR forbids the use of a considered [non-secure](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/security/non-secure-functions.html) function, `eval()`.

> All scripting languages used in web applications have a form of an eval call which receives code at runtime and executes it. If code is crafted using unvalidated and unescaped user input code injection can occur which allows an attacker to subvert application logic and eventually to gain local access.

Take the following PHP script as an example:
```php
<?php

// index.php

declare(strict_types=1);

$x = $_GET['x'];
$y = $_GET['y'];
$z = $_GET['z'];

eval("echo $x * $y / $z;");
```
Using the following query string: 

```
?x="<pre>", print_r(scandir('./')), "</pre>";//&y=5&z=7
```

Displays the following in the browser:
```php
Array
(
    [0] => .
    [1] => ..
    [2] => .valet-env.php
    [3] => .vscode
    [4] => composer.json
    [5] => composer.lock
    [6] => index.php
    [7] => phpcs.xml
    [8] => src
    [9] => vendor
)
1
```
A malicious user has more creative exploits than the example but it demonstrates the risk. 

Information taken from [OWASP](https://cheatsheetseries.owasp.org/cheatsheets/Injection_Prevention_Cheat_Sheet.html#scripting-languages), example taken from [SE INFOSEC](https://security.stackexchange.com/questions/203508/eval-exploitation-payload).

For a real example see: [TRUESEC](https://www.truesec.com/hub/blog/from-s3-bucket-to-laravel-unserialize-rce) which exploits `unserialize()` ([forbidden in PR 33](https://github.com/isaaceindhoven/php-code-sniffer-standard/pull/33)), which, through a so called gadget chain gets to a class that makes use of `eval()`, resulting in the establishment of a reverse shell.

With `eval()` added to the list of forbidden functions, the user would get the following error notification:
```shell
------------------------------------------------------------------------------------------------------------------------
9 | ERROR | The use of function eval() is forbidden (Generic.PHP.ForbiddenFunctions.Found)
------------------------------------------------------------------------------------------------------------------------
```
The PHP documentation also reports a warning/caution about `eval()` in its [documentation](https://www.php.net/manual/en/function.eval.php#refsect1-function.eval-description).