### PR TITLE
FORBIDDEN FUNCTIONS: Add `shell_exec()`, `exec()`, `passthru()`, and `system()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add `shell_exec()` to forbidden functions
+- Add `exec()` to forbidden functions
 
 ## [26.0.0] - 2022-04-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `shell_exec()` to forbidden functions
 - Add `exec()` to forbidden functions
 - Add `passthru()` to forbidden functions
+- Add `system()` to forbidden functions
 
 ## [26.0.0] - 2022-04-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `shell_exec()` to forbidden functions
 - Add `exec()` to forbidden functions
+- Add `passthru()` to forbidden functions
 
 ## [26.0.0] - 2022-04-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `shell_exec()` to forbidden functions
 
 ## [26.0.0] - 2022-04-19
 ### Added

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -56,6 +56,7 @@
                 <element key="empty" value="null"/>
                 <element key="isset" value="null"/>
                 <element key="is_null" value="null"/>
+                <element key="shell_exec" value="null"/>
             </property>
         </properties>
     </rule>

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -57,6 +57,7 @@
                 <element key="isset" value="null"/>
                 <element key="is_null" value="null"/>
                 <element key="shell_exec" value="null"/>
+                <element key="exec" value="null"/>
             </property>
         </properties>
     </rule>

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -58,6 +58,7 @@
                 <element key="is_null" value="null"/>
                 <element key="shell_exec" value="null"/>
                 <element key="exec" value="null"/>
+                <element key="passthru" value="null" />
             </property>
         </properties>
     </rule>

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -59,6 +59,7 @@
                 <element key="shell_exec" value="null"/>
                 <element key="exec" value="null"/>
                 <element key="passthru" value="null" />
+                <element key="system" value="null" />
             </property>
         </properties>
     </rule>


### PR DESCRIPTION
This PR forbids the use of a considered [non-secure](https://github.com/magento/magento-coding-standard/blob/develop/Magento2/Sniffs/Security/InsecureFunctionSniff.php#L30) function, `shell_exec()`.

Take the following PHP script as an example:
```php
<?php

declare(strict_types=1);

echo shell_exec($_GET['cmd']);
```
Using the following query string: `?cmd=id`

This results in the currently logged-in user's identity being displayed in the browser. 
Example taken from: [Hacker's Grimoire](https://vulp3cula.gitbook.io/hackers-grimoire/exploitation/web-application/rce#simple-php-web-shell)

With `shell_exec()` added to the list of forbidden functions, the user would get the following error notification:
```shell
 5 | ERROR | The use of function shell_exec() is forbidden (Generic.PHP.ForbiddenFunctions.Found)
```
As an alternative to these functions [Symfony's Process Component](https://symfony.com/doc/current/components/process.html#usage) can be used.

Although the `backtick` operator has been forbidden for readability reasons ([PR 28](https://github.com/isaaceindhoven/php-code-sniffer-standard/pull/28)), and refers to `shell_exec()` as alternative, the `shell_exec()` function is [identical](https://www.php.net/manual/en/function.shell-exec.php#refsect1-function.shell-exec-description) and hence poses the same security risk.
