### PR TITLE
FORBIDDEN FUNCTIONS: Add `assert()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `assert()` to forbidden functions
 
 ## [26.0.0] - 2022-04-19
 ### Added

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -56,6 +56,7 @@
                 <element key="empty" value="null"/>
                 <element key="isset" value="null"/>
                 <element key="is_null" value="null"/>
+                <element key="assert" value="null"/>
             </property>
         </properties>
     </rule>


### PR DESCRIPTION
This PR forbids the use of a considered [non-secure](https://github.com/magento/magento-coding-standard/blob/develop/Magento2/Sniffs/Security/InsecureFunctionSniff.php#L21) function, `assert()`.

Preconditions:
- PHP Version: `7.4.29`
- php.ini: `zend.assertions = 1` (default)
- [assertion](https://www.php.net/manual/en/function.assert.php#refsect1-function.assert-parameters) parameter is a string expression

Take the following PHP script as an example:
```php
<?php

declare(strict_types=1);

// Terminate script execution on failed assertions.
ini_set('assert.bail', '1');

$adminId = 1234;
$userId = $_GET['uid'];

assert("$userId === $adminId");

echo 'Hello, Admin!';
```
Using the following query string: `?uid=true;//`

This results in the text `Hello, Admin!` displayed in the browser.

According to the [documentation](https://www.php.net/manual/en/function.assert.php#refsect2-function.assert-unknown-descriptioo) this is due to the string assertion being evaluated as PHP code by `assert()`. This is however resolved as of PHP >= 8.0 according to the [changelog](https://www.php.net/manual/en/function.assert.php#refsect1-function.assert-changelog).

This does not resolve all potential issues that can arise from using `assert()`. Take for example the following script:
```php
<?php

declare(strict_types=1);

ini_set('assert.bail', '1');

class Foo
{
    private int $value;

    public function __construct(int $value)
    {
        assert($value >= 1);

        $this->value = $value;
    }
}

$f = new Foo(0);
```

At first this seems to work as intended, the script should fail as an invalid value is given and the assertion will evaluate to `false`.

In case the [zend.assertions](https://www.php.net/manual/en/ini.core.php#ini.zend.assertions) is set to 0, the assertion code is generated but skipped, or when it is set to -1, the code will not be generated, making the assertions zero-cost (production mode). As a result, an object is created of `Foo::class` with an invalid value.

In the other case `zend.assertions` is set to its default 1, but through a call to `ini_set('assert.active', '0');` the evaluation of `assert()` is turned off during runtime. This could be done in a file different from the one in which the `assert()` statement is located, which could be hard to debug.

With `assert()` added to the list of forbidden functions, the user would get the following error notification (based on the last example):

```shell
 13 | ERROR   | The use of function assert() is forbidden (Generic.PHP.ForbiddenFunctions.Found)
```

As an alternative to using `assert()` to assert that a value meets an expectation, a regular conditional statement can be used and an instance of `Exception::class` can be thrown.
```php
class Foo
{
    private int $value;

    public function __construct(int $value)
    {
        if ($value < 1) {
            throw new LogicException('Value must be >= 1');
        }

        $this->value = $value;
    }
}
```