### PR TITLE
Add allow-plugin config to composer.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add allow-plugin config to composer.json 
 
 ## [28.0.0] - 2022-06-22
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -41,5 +41,11 @@
     },
     "support": {
         "issues": "https://github.com/isaaceindhoven/php-code-sniffer-standard"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "phpstan/extension-installer": true
+        }
     }
 }


### PR DESCRIPTION
This PR adds the `allow-plugin` configuration to the `composer.json`.

This is needed to support Composer 2.2+ for development purposes from July 2022.
For details, see the [documentation of the allow-plugin config setting](https://getcomposer.org/doc/06-config.md#allow-plugins).