### PR TITLE
Add support for Slevomat Coding Standard v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add support for Slevomat Coding Standard v8
 
 ## [28.0.0] - 2022-06-22
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-        "slevomat/coding-standard": "^7.0.19",
+        "slevomat/coding-standard": "^7.0.19 || ^8.0",
         "squizlabs/php_codesniffer": "^3.6.0",
         "phpcompatibility/php-compatibility": "^9.3"
     },


### PR DESCRIPTION
This PR adds support for Slevomat Coding Standard v8.

The breaking changes introduced in this new major version are not applicable to the sniffs used by the ISAAC PHP_CodeSniffer Standard.