### PR TITLE
RULE SET: Add `Generic.Formatting.SpaceAfterNot` with spacing 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [40](https://github.com/isaaceindhoven/php-code-sniffer-standard/pull/40): Add the `Generic.Formatting.SpaceAfterNot` rule with spacing 0
 
 ## [28.1.0] - 2022-06-22
 ### Added

--- a/src/Standards/ISAAC/ruleset.xml
+++ b/src/Standards/ISAAC/ruleset.xml
@@ -37,6 +37,11 @@
             <property name="spacing" value="1"/>
         </properties>
     </rule>
+    <rule ref="Generic.Formatting.SpaceAfterNot">
+        <properties>
+            <property name="spacing" value="0"/>
+        </properties>
+    </rule>
     <rule ref="Generic.Metrics.CyclomaticComplexity">
         <properties>
             <property name="complexity" value="10"/>


### PR DESCRIPTION
This PR disallows *inconsistent amounts of spacing* between the logical negation and a conditional statement by adding the `Generic.Formatting.SpaceAfterNot` with spacing set to `0`.

Consider the following PHP code:
```php
<?php

declare(strict_types=1);

if (! is_string($value)) {
    throw new RuntimeException('The given value is not a string');
}
```
With the current ruleset, this does not report any error.

After merging this PR, the following error is reported:
```shell
--------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------------------------------------
 5 | ERROR | [x] Expected 0 space(s) after NOT operator; 1 found
   |       |     (Generic.Formatting.SpaceAfterNot.Incorrect)
--------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------------------------------------
```

Repairing this error will result in the following:
```php
<?php

declare(strict_types=1);

if (!is_string($value)) {
    throw new RuntimeException('The given value is not a string');
}

```
